### PR TITLE
Support creating a protobuf from a given buffer

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -338,6 +338,16 @@ impl<T> ProtoBufMut<T> {
 
 impl ProtoBuf {
     /**
+    Treat a buffer as a pre-encoded message.
+
+    No validation is performed on the given buffer; it's expected to already
+    contain a valid message.
+    */
+    pub fn pre_encoded(buf: impl Into<Box<[u8]>>) -> Self {
+        ProtoBuf { bytes: buf.into(), chunks: [].into() }
+    }
+
+    /**
     Get the length in bytes of the encoded payload.
     */
     pub fn len(&self) -> usize {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1250,6 +1250,9 @@ mod tests {
 #[track_caller]
 #[cfg(test)]
 fn assert_proto(expected: &[u8], actual: &[u8]) {
+    let roundtrip = sval_protobuf::buf::ProtoBuf::pre_encoded(actual);
+    assert_eq!(actual, &*roundtrip.to_vec());
+
     assert_eq!(
         expected,
         actual,


### PR DESCRIPTION
This PR lets you treat a byte buffer as a `ProtoBuf` message. It doesn't check the buffer to ensure it's a valid message since this library doesn't support decoding.