### PR TITLE
Always encode 128bit numbers as 16 byte arrays

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@ Anonymous tuples are also messages:
 2: {"My Message"}
 3: {"Some amazing content"}
 ```
+
+128bit numbers are always encoded as a 16 byte buffer with the little-endian bytes of the value.
 */
 
 #![no_std]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -244,6 +244,14 @@ impl<'sval> sval::Stream<'sval> for ProtoBufStream {
         }
     }
 
+    fn u128(&mut self, value: u128) -> sval::Result {
+        let bytes = value.to_le_bytes();
+
+        self.binary_begin(Some(bytes.len()))?;
+        self.binary_fragment_computed(&bytes)?;
+        self.binary_end()
+    }
+
     fn i32(&mut self, value: i32) -> sval::Result {
         if value == 0 {
             self.null()
@@ -296,6 +304,14 @@ impl<'sval> sval::Stream<'sval> for ProtoBufStream {
                 }
             }
         }
+    }
+
+    fn i128(&mut self, value: i128) -> sval::Result {
+        let bytes = value.to_le_bytes();
+
+        self.binary_begin(Some(bytes.len()))?;
+        self.binary_fragment_computed(&bytes)?;
+        self.binary_end()
     }
 
     fn f32(&mut self, value: f32) -> sval::Result {

--- a/test/protos/cases.proto
+++ b/test/protos/cases.proto
@@ -8,6 +8,11 @@ message Basic {
     optional int32 index = 3;
 }
 
+message Num128Bit {
+    bytes u = 1;
+    bytes i = 2;
+}
+
 message BasicScalar {
     double f64 = 1;
     float f32 = 2;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -327,6 +327,72 @@ mod tests {
     }
 
     #[test]
+    fn num_128bit_small() {
+        let prost = {
+            let mut buf = Vec::new();
+
+            protos::cases::Num128Bit {
+                u: 42u128.to_le_bytes().to_vec(),
+                i: (-42i128).to_le_bytes().to_vec(),
+            }
+            .encode(&mut buf)
+            .unwrap();
+
+            buf
+        };
+
+        let sval = {
+            #[derive(Value)]
+            pub struct Num128Bit {
+                u: u128,
+                i: i128,
+            }
+
+            sval_protobuf::stream_to_protobuf(Num128Bit {
+                u: 42u128,
+                i: -42i128,
+            })
+            .to_vec()
+            .into_owned()
+        };
+
+        assert_proto(&prost, &sval);
+    }
+
+    #[test]
+    fn num_128bit_large() {
+        let prost = {
+            let mut buf = Vec::new();
+
+            protos::cases::Num128Bit {
+                u: u128::MAX.to_le_bytes().to_vec(),
+                i: i128::MIN.to_le_bytes().to_vec(),
+            }
+            .encode(&mut buf)
+            .unwrap();
+
+            buf
+        };
+
+        let sval = {
+            #[derive(Value)]
+            pub struct Num128Bit {
+                u: u128,
+                i: i128,
+            }
+
+            sval_protobuf::stream_to_protobuf(Num128Bit {
+                u: u128::MAX,
+                i: i128::MIN,
+            })
+            .to_vec()
+            .into_owned()
+        };
+
+        assert_proto(&prost, &sval);
+    }
+
+    #[test]
     fn basic_non_contiguous_fields() {
         let prost = {
             let mut buf = Vec::new();


### PR DESCRIPTION
This is a breaking change, so will require a `0.2.0` release.

`sval` encodes 128bit values differently depending on how big they are. This isn't helpful for protobuf, which uses a fixed schema. This PR makes 128bit numbers always encode as a little-endian 16 byte buffer of the number.