### PR TITLE
Support pre-allocating and re-using buffers while encoding

### DIFF
--- a/src/buf/cursor.rs
+++ b/src/buf/cursor.rs
@@ -4,6 +4,9 @@ use crate::raw::VarInt;
 use alloc::{boxed::Box, vec::Vec};
 use core::{cmp, ops::Range};
 
+/**
+A reader over an encoded protobuf message that offers a similar API to the `bytes` crate.
+*/
 pub struct ProtoBufCursor {
     bytes: Box<[u8]>,
     chunks: IterBox<LenPrefixedChunk>,
@@ -107,11 +110,22 @@ impl ProtoBufCursor {
         }
     }
 
+    /**
+    Get the next contiguous chunk of data in the message.
+
+    The size of chunks will depend on how the message was originally encoded.
+    Messages produced from streams of values of unknown size will produce smaller chunks.
+    */
     #[inline]
     pub fn chunk(&self) -> &[u8] {
         self.current.as_slice(&self.bytes)
     }
 
+    /**
+    Advance the cursor by `cnt`.
+
+    This method will panic if `cnt` is greater than [`Self::remaining`].
+    */
     pub fn advance(&mut self, mut cnt: usize) {
         self.remaining = self.remaining.saturating_sub(cnt);
 
@@ -135,11 +149,17 @@ impl ProtoBufCursor {
         }
     }
 
+    /**
+    The number of bytes left to read.
+    */
     #[inline]
     pub fn remaining(&self) -> usize {
         self.remaining
     }
 
+    /**
+    Copy all remaining bytes into a contiguous vec.
+    */
     pub fn copy_to_vec(&mut self, v: &mut Vec<u8>) {
         v.reserve(self.remaining());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ Anonymous tuples are also messages:
 128bit numbers are always encoded as a 16 byte buffer with the little-endian bytes of the value.
 */
 
+#![deny(missing_docs)]
 #![no_std]
 
 extern crate alloc;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -5,6 +5,8 @@ The protobuf wire format is described in detail in [the docs](https://protobuf.d
 It's a length-prefixed format that makes extensive use of variable-length integers.
 */
 
+#![allow(missing_docs)]
+
 use core::mem;
 
 #[derive(Debug, Clone, Copy)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -185,6 +185,13 @@ pub struct ProtoBufStreamReusable(ProtoBufMutReusable<u64>);
 
 impl ProtoBufStreamReusable {
     /**
+    Create a new, empty set of re-usable internals.
+    */
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /**
     Set the initial capacity of the next encoder.
     */
     pub fn with_capacity(mut self, capacity: Capacity) -> Self {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,6 +18,17 @@ pub fn stream_to_protobuf(v: impl sval::Value) -> ProtoBuf {
     stream.buf.freeze()
 }
 
+/**
+An [`sval::Stream`] that encodes into the protobuf wire format.
+*/
+#[derive(Debug)]
+pub struct ProtoBufStream {
+    buf: ProtoBufMut<u64>,
+    field: FieldState,
+    len: LenState,
+    one_of: OneOfState,
+}
+
 impl ProtoBufStream {
     /**
     Create a new protobuf stream.
@@ -162,17 +173,6 @@ struct LenState {
 #[derive(Debug)]
 struct OneOfState {
     is_internally_tagged: bool,
-}
-
-/**
-An [`sval::Stream`] that encodes into the protobuf wire format.
-*/
-#[derive(Debug)]
-pub struct ProtoBufStream {
-    buf: ProtoBufMut<u64>,
-    field: FieldState,
-    len: LenState,
-    one_of: OneOfState,
 }
 
 /**

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,9 @@
-use crate::buf::{ProtoBuf, ProtoBufMut};
+use crate::buf::{ProtoBuf, ProtoBufMut, ProtoBufMutReusable};
 use crate::raw::WireType;
 use crate::tags;
 use sval::{Index, Label, Tag};
+
+pub use crate::buf::Capacity;
 
 /**
 Encode a value to the protobuf wire format.
@@ -9,32 +11,99 @@ Encode a value to the protobuf wire format.
 Standalone scalar values will be wrapped in a message with a field number `1`.
 */
 pub fn stream_to_protobuf(v: impl sval::Value) -> ProtoBuf {
-    let mut stream = ProtoBufStream {
-        buf: ProtoBufMut::new(1),
-        field: FieldState {
-            number: 1,
-            ty: FieldType::Root,
-        },
-        len: LenState {
-            is_packed: false,
-            is_prefixed: false,
-        },
-        one_of: OneOfState {
-            is_internally_tagged: false,
-        },
-    };
+    let mut stream = ProtoBufStream::new();
 
     let _ = v.stream(&mut stream);
 
     stream.buf.freeze()
 }
 
-#[derive(Debug)]
-struct ProtoBufStream {
-    buf: ProtoBufMut<u64>,
-    field: FieldState,
-    len: LenState,
-    one_of: OneOfState,
+impl ProtoBufStream {
+    /**
+    Create a new protobuf stream.
+    */
+    pub fn new() -> Self {
+        Self::from_buf(ProtoBufMut::new(1))
+    }
+
+    /**
+    Create a new protobuf stream from reusable internals.
+    */
+    pub fn new_reuse(reuse: ProtoBufStreamReusable) -> Self {
+        Self::from_buf(ProtoBufMut::new_reuse(reuse.0, 1))
+    }
+
+    fn from_buf(buf: ProtoBufMut<u64>) -> Self {
+        ProtoBufStream {
+            buf,
+            field: FieldState {
+                number: 1,
+                ty: FieldType::Root,
+            },
+            len: LenState {
+                is_packed: false,
+                is_prefixed: false,
+            },
+            one_of: OneOfState {
+                is_internally_tagged: false,
+            },
+        }
+    }
+
+    /**
+    Complete the stream, returning the encoded protobuf message.
+    */
+    #[inline]
+    pub fn freeze(self) -> ProtoBuf {
+        self.buf.freeze()
+    }
+
+    /**
+    Complete the stream, returning the encoded protobuf message.
+
+    This method also returns some temporary allocations and metadata about the encoded payload
+    that can be used to encode a similar payload more efficiently later.
+    */
+    #[inline]
+    pub fn freeze_reuse(self) -> (ProtoBuf, ProtoBufStreamReusable) {
+        let (buf, reuse) = self.buf.freeze_reuse();
+
+        (buf, ProtoBufStreamReusable(reuse))
+    }
+
+    fn internally_tagged_begin(&mut self, index: Option<&Index>) {
+        if self.one_of.is_internally_tagged {
+            self.one_of.is_internally_tagged = false;
+
+            if self.field.is_set() {
+                self.field.push(WireType::Len, &mut self.buf);
+                self.buf.begin_len(1);
+            }
+
+            if let Some(index) = index {
+                self.field.set(index);
+            }
+        }
+    }
+
+    fn internally_tagged_end(&mut self, index: Option<&Index>) {
+        if index.is_some() {
+            self.one_of.is_internally_tagged = true;
+        }
+    }
+
+    fn root_begin(&mut self) {
+        if let FieldType::Root = self.field.ty {
+            self.field = FieldState {
+                ty: FieldType::Any,
+                number: 0,
+            }
+        }
+    }
+
+    fn field_begin(&mut self) {
+        self.one_of.is_internally_tagged = false;
+    }
 }
 
 #[derive(Debug)]
@@ -95,39 +164,39 @@ struct OneOfState {
     is_internally_tagged: bool,
 }
 
-impl ProtoBufStream {
-    fn internally_tagged_begin(&mut self, index: Option<&Index>) {
-        if self.one_of.is_internally_tagged {
-            self.one_of.is_internally_tagged = false;
+/**
+An [`sval::Stream`] that encodes into the protobuf wire format.
+*/
+#[derive(Debug)]
+pub struct ProtoBufStream {
+    buf: ProtoBufMut<u64>,
+    field: FieldState,
+    len: LenState,
+    one_of: OneOfState,
+}
 
-            if self.field.is_set() {
-                self.field.push(WireType::Len, &mut self.buf);
-                self.buf.begin_len(1);
-            }
+/**
+The re-usable internals of a [`ProtoBufStream`] that can optimize a later encoding.
 
-            if let Some(index) = index {
-                self.field.set(index);
-            }
-        }
+This type can be produced through [`ProtoBufStream::freeze_reuse`].
+*/
+#[derive(Clone, Default)]
+pub struct ProtoBufStreamReusable(ProtoBufMutReusable<u64>);
+
+impl ProtoBufStreamReusable {
+    /**
+    Set the initial capacity of the next encoder.
+    */
+    pub fn with_capacity(mut self, capacity: Capacity) -> Self {
+        self.0 = self.0.with_capacity(capacity);
+        self
     }
 
-    fn internally_tagged_end(&mut self, index: Option<&Index>) {
-        if index.is_some() {
-            self.one_of.is_internally_tagged = true;
-        }
-    }
-
-    fn root_begin(&mut self) {
-        if let FieldType::Root = self.field.ty {
-            self.field = FieldState {
-                ty: FieldType::Any,
-                number: 0,
-            }
-        }
-    }
-
-    fn field_begin(&mut self) {
-        self.one_of.is_internally_tagged = false;
+    /**
+    Get the current initial capacity.
+    */
+    pub fn capacity(&self) -> Capacity {
+        self.0.capacity()
     }
 }
 


### PR DESCRIPTION
This PR adds `ProtoBufMutReusable` and `ProtoBufStreamReusable` that can be used to re-use internal buffers and pre-allocate non-reusable buffers with good sizes.

Most of our time spent encoding unknown messages comes from re-allocation, since we don't know the size of the message upfront. When encoding streams of similarly shaped messages, we can avoid needing to re-allocate as much by finding an appropriate size to pre-allocate to.