### PR TITLE
Rountrip ProtoBuf values when streamed from the root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ optional = true
 [dev-dependencies.sval_derive]
 version = "2.8"
 features = ["alloc", "flatten"]
+
+[profile.release]
+debug = true

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -17,7 +17,7 @@ path = "../test"
 version = "2.8"
 
 [dependencies.prost]
-version = "0.13"
+version = "0.14"
 
 [dependencies.bytes]
 version = "1"

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -402,7 +402,7 @@ impl ProtoBuf {
     /**
     Get the payload as a contiguous buffer.
     */
-    pub fn to_vec(&self) -> Cow<[u8]> {
+    pub fn to_vec(&self) -> Cow<'_, [u8]> {
         visit::to_vec(&self.bytes, &self.chunks)
     }
 

--- a/src/buf/visit.rs
+++ b/src/buf/visit.rs
@@ -1,4 +1,4 @@
-use crate::raw::VarInt;
+use crate::{raw::VarInt, tags};
 use alloc::{borrow::Cow, vec::Vec};
 
 use super::LenPrefixedChunk;
@@ -58,6 +58,8 @@ pub(super) fn to_stream<'a>(
     chunks: &[LenPrefixedChunk],
     stream: &mut (impl sval::Stream<'a> + ?Sized),
 ) -> sval::Result {
+    stream.tagged_begin(Some(&tags::PROTOBUF_PRE_ENCODED), None, None)?;
+
     if chunks.len() == 0 {
         stream.binary_begin(Some(bytes.len()))?;
         stream.binary_fragment(bytes)?;
@@ -88,7 +90,8 @@ pub(super) fn to_stream<'a>(
         visitor.result?;
     }
 
-    stream.binary_end()
+    stream.binary_end()?;
+    stream.tagged_end(Some(&tags::PROTOBUF_PRE_ENCODED), None, None)
 }
 
 #[inline(always)]

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -26,3 +26,8 @@ Variable-length zigzag encoding can be more efficient than the default strategy
 for negative values.
 */
 pub const PROTOBUF_VARINT_SIGNED: sval::Tag = sval::Tag::new("PROTOBUF_VARINT_SIGNED");
+
+/**
+A tag for round-tripping pre-encoded protobuf messages.
+*/
+pub(crate) const PROTOBUF_PRE_ENCODED: sval::Tag = sval::Tag::new("PROTOBUF_PRE_ENCODED");

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -16,10 +16,10 @@ version = "2.8"
 features = ["flatten"]
 
 [dependencies.prost]
-version = "0.13"
+version = "0.14"
 
 [dependencies.bytes]
 version = "1"
 
 [build-dependencies.prost-build]
-version = "0.13"
+version = "0.14"

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1889,14 +1889,29 @@ mod tests {
 #[cfg(test)]
 fn assert_proto(expected: &[u8], actual: &[u8]) {
     let roundtrip = sval_protobuf::buf::ProtoBuf::pre_encoded(actual);
-    assert_eq!(actual, &*roundtrip.to_vec());
+    assert_eq!(
+        actual,
+        &*roundtrip.to_vec(),
+        "pre-encoded roundtrip\nexpected:\n{}\nactual:\n{}",
+        inspect(&expected),
+        inspect(&actual),
+    );
+
+    let roundtrip_stream = sval_protobuf::stream_to_protobuf(roundtrip);
+    assert_eq!(
+        actual,
+        &*roundtrip_stream.to_vec(),
+        "stream roundtrip\nexpected:\n{}\nactual:\n{}",
+        inspect(&expected),
+        inspect(&actual),
+    );
 
     assert_eq!(
         expected,
         actual,
         "\nexpected:\n{}\nactual:\n{}",
         inspect(&expected),
-        inspect(&actual)
+        inspect(&actual),
     )
 }
 


### PR DESCRIPTION
This PR makes sure that streaming a previously encoded `ProtoBuf` will roundtrip to the same value, instead of prepending it with a redundant length.