### PR TITLE
Make prost build optional

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -7,17 +7,22 @@ edition = "2021"
 [lib]
 path = "lib.rs"
 
+[features]
+prost = ["dep:prost", "sval_protobuf_test/prost"]
+
 [dependencies.sval_protobuf]
 path = "../"
 
 [dependencies.sval_protobuf_test]
 path = "../test"
+default-features = false
 
 [dependencies.sval]
 version = "2.8"
 
 [dependencies.prost]
 version = "0.14"
+optional = true
 
 [dependencies.bytes]
 version = "1"

--- a/bench/lib.rs
+++ b/bench/lib.rs
@@ -2,11 +2,15 @@
 #![feature(test)]
 extern crate test;
 
-use ::prost::Message as _;
+#[cfg(feature = "prost")]
+use prost::Message as _;
+#[cfg(feature = "prost")]
+use sval_protobuf_test::opentelemetry::data_prost;
 
-use sval_protobuf_test::opentelemetry::{data_prost, data_sval};
+use sval_protobuf_test::opentelemetry::data_sval;
 
 #[bench]
+#[cfg(feature = "prost")]
 fn export_logs_service_request_prost(b: &mut test::Bencher) {
     b.iter(|| data_prost::export_logs_service_request().encode_to_vec());
 }
@@ -41,6 +45,7 @@ fn export_logs_service_request_sval_pre_alloc(b: &mut test::Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "prost")]
 fn log_record1_prost(b: &mut test::Bencher) {
     b.iter(|| data_prost::log_record1().encode_to_vec());
 }
@@ -51,6 +56,7 @@ fn log_record1_sval(b: &mut test::Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "prost")]
 fn log_record2_prost(b: &mut test::Bencher) {
     b.iter(|| data_prost::log_record2().encode_to_vec());
 }
@@ -61,6 +67,7 @@ fn log_record2_sval(b: &mut test::Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "prost")]
 fn log_record3_prost(b: &mut test::Bencher) {
     b.iter(|| data_prost::log_record3().encode_to_vec());
 }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -5,6 +5,9 @@ publish = false
 edition = "2021"
 build = "build.rs"
 
+[features]
+default = ["prost"]
+
 [dependencies.sval_protobuf]
 path = "../"
 
@@ -17,6 +20,7 @@ features = ["flatten"]
 
 [dependencies.prost]
 version = "0.14"
+optional = true
 
 [dependencies.bytes]
 version = "1"

--- a/test/build.rs
+++ b/test/build.rs
@@ -1,15 +1,18 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    let mut config = prost_build::Config::new();
-    config.btree_map(&["."]);
-    config.compile_protos(
-        &[
-            "protos/cases.proto",
-            "protos/opentelemetry/proto/collector/logs/v1/logs_service.proto",
-        ],
-        &["protos/"],
-    )?;
+    #[cfg(feature = "prost")]
+    {
+        let mut config = prost_build::Config::new();
+        config.btree_map(&["."]);
+        config.compile_protos(
+            &[
+                "protos/cases.proto",
+                "protos/opentelemetry/proto/collector/logs/v1/logs_service.proto",
+            ],
+            &["protos/"],
+        )?;
+    }
 
     Ok(())
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "prost")]
 pub mod protos {
     pub mod cases {
         include!(concat!(env!("OUT_DIR"), "/sval.protobuf.cases.rs"));
@@ -45,7 +46,7 @@ pub mod protos {
 
 pub mod opentelemetry;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "prost"))]
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
@@ -1886,7 +1887,7 @@ mod tests {
 }
 
 #[track_caller]
-#[cfg(test)]
+#[cfg(all(test, feature = "prost"))]
 fn assert_proto(expected: &[u8], actual: &[u8]) {
     let roundtrip = sval_protobuf::buf::ProtoBuf::pre_encoded(actual);
     assert_eq!(
@@ -1915,12 +1916,12 @@ fn assert_proto(expected: &[u8], actual: &[u8]) {
     )
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "prost"))]
 fn inspect(encoded: &[u8]) -> String {
     protoscope(encoded).unwrap_or_else(|_| "<protoscope not available>".to_owned())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "prost"))]
 fn protoscope(encoded: &[u8]) -> Result<String, Box<dyn std::error::Error + 'static>> {
     use std::{
         io::{Read, Write},

--- a/test/src/opentelemetry.rs
+++ b/test/src/opentelemetry.rs
@@ -1,7 +1,9 @@
+#[cfg(feature = "prost")]
 pub mod data_prost;
+
 pub mod data_sval;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "prost"))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
This PR makes the `prost` parts of the build optional so some features can still be checked in environments that don't have a readily available `protoc`, like RISC-V.